### PR TITLE
Require igraph version 2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: klassR
 Type: Package
 Title: Classifications and Codelists for Statistics Norway
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: 
   c(person(given = "Susie",
            family = "Jentoft",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Description: Functions to search, retrieve, apply and update classifications
   to choose language, hierarchical level and formatting.
 Depends:
     R (>= 3.5.0)
-Imports: tm, httr, jsonlite, igraph, methods
+Imports: tm, httr, jsonlite, igraph (>= 2.1.1), methods
 URL: https://statisticsnorway.github.io/ssb-klassr/
 BugReports: https://github.com/statisticsnorway/ssb-klassr/issues
 License: MIT + file LICENSE


### PR DESCRIPTION
Using older versions of `igraph` created errors for some users when calling `update_klass`. We require the (current) newest version of `igraph`, which fixed errors in some cases.